### PR TITLE
Fixed adding staticLibs and frameworks when target doesn't match xcodeproj name

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1080,7 +1080,8 @@ pbxProject.prototype.addTargetDependencies = function({
 pbxProject.prototype.addTargetDependency = function(
   target,
   dependencyTargets,
-  remoteGlobalIDString
+  remoteGlobalIDString,
+  remoteInfo
 ) {
   target = target || this.getFirstTarget().uuid
 
@@ -1119,7 +1120,7 @@ pbxProject.prototype.addTargetDependency = function(
         containerPortal_comment: path.basename(file.path).replace('"', ''),
         proxyType: 1,
         remoteGlobalIDString: dependencyTargetUuid,
-        remoteInfo: path.basename(file.path).replace('.xcodeproj"', ''),
+        remoteInfo: remoteInfo || path.basename(file.path).replace('.xcodeproj"', ''),
       },
       targetDependency = {
         isa: pbxTargetDependency,
@@ -1564,13 +1565,15 @@ pbxProject.prototype.addProject = function(
     this.addProjectReference(productGroup, projectFile)
   } else {
     if (options.staticLibs && options.staticLibs.length > 0) {
-      this.addTargetDependency(target, [`"${path.basename(projectPath)}"`])
       // Add each static lib
       for (var staticLib of options.staticLibs) {
+        var uuid = this.generateUuid()
+        this.addTargetDependency(target, [`"${path.basename(projectPath)}"`], uuid, staticLib.target)
+
         var file = new pbxFile(staticLib.name)
         if (this.hasFile(file.path)) continue
 
-        file.uuid = this.generateUuid()
+        file.uuid = uuid
         file.fileRef = this.generateUuid()
 
         this.addToPbxBuildFileSection(file) // PBXBuildFile
@@ -1612,14 +1615,12 @@ pbxProject.prototype.addProject = function(
         file.uuid = this.generateUuid()
         file.fileRef = this.generateUuid()
 
-        if (!options.addAsTargetDependency) {
-          // The following will add the framework to 'Link Binary With Libraries'
-          // section of 'Build Phases'
-          // Only done if addAsTargetDependency is falsy
-          this.addToPbxBuildFileSection(file) // PBXBuildFile
-          //this.addToPbxFileReferenceSection(file);    // PBXFileReference
-          this.addToPbxFrameworksBuildPhase(file) // PBXFrameworksBuildPhase
-        }
+
+        // The following will add the framework to 'Link Binary With Libraries'
+        // section of 'Build Phases'
+        this.addToPbxBuildFileSection(file) // PBXBuildFile
+        //this.addToPbxFileReferenceSection(file);    // PBXFileReference
+        this.addToPbxFrameworksBuildPhase(file) // PBXFrameworksBuildPhase
 
         var uuidInContainingProject
         if (!framework.productReference) {
@@ -1631,21 +1632,13 @@ pbxProject.prototype.addProject = function(
         }
 
         if (options.addAsTargetDependency) {
-          // TODO : Should infer the targetReference if not explicitly
-          // provided (as it is done for productReference above)
-          if (!framework.targetReference) {
-            throw new Error('addAsTargetDependency: targetReference is missing')
-          }
-
           // Add Framework project to 'Target Dependencies' section of
           // 'Build Phases'
-          // Only done in case addAsTargetDependency evaluate to truthy
-          // Using this option will not add the framework to the
-          // 'Link Binary With Libraries' section of 'Build Phases'
           this.addTargetDependency(
             target,
             [`"${path.basename(projectPath)}"`],
-            framework.targetReference
+            file.uuid,
+            framework.target
           )
         }
 


### PR DESCRIPTION
While trying to add support for Lottie, we ran into a problem where xcode won't pick up the Target Dependency if the `remoteInfo` does not match the actual target name of the project.

Also fixes a problem if you would be to add several static libs as target dependency, as there need to be one target dependency added per lib.